### PR TITLE
winevulkan: Fix winelib wrapper

### DIFF
--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -1662,6 +1662,10 @@ static void *wine_vk_get_global_proc_addr(const char *name)
  */
 void *native_vkGetInstanceProcAddrWINE(VkInstance instance, const char *name)
 {
+    wine_vk_init_once();
+    if (!vk_funcs)
+        return NULL;
+
     return vk_funcs->p_vkGetInstanceProcAddr(instance, name);
 }
 


### PR DESCRIPTION
Bug introduced by commit aec196878875e92d0b404a6f982cea6667768696

Since you currently working on winevulkan part, may I ask you to fix this bug too.

Should be something like this, to init `vk_funcs`. 
Thanks.